### PR TITLE
adds target owner for acl when copying across accounts

### DIFF
--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -330,7 +330,8 @@ class FileInfo(TaskInfo):
         src_bucket, src_key = find_bucket_key(self.src)
         bucket, key = find_bucket_key(self.dest)
         src_acl = self.client.get_object_acl(Bucket=src_bucket, Key=src_key)
-        acl = {'Grants': src_acl['Grants'], 'Owner': src_acl['Owner']}
+        dest_acl = self.client.get_object_acl(Bucket=bucket, Key=key)
+        acl = {'Grants': src_acl['Grants'], 'Owner': dest_acl['Owner']}
 
         self.client.put_object_acl(
             Bucket=bucket, Key=key, AccessControlPolicy=acl


### PR DESCRIPTION
As per the latest request by https://github.com/andyjojo

https://github.com/aws/aws-cli/pull/1535#issuecomment-271241307